### PR TITLE
fix, tested by editing the main.js file in obsidian itself

### DIFF
--- a/src/header.tsx
+++ b/src/header.tsx
@@ -14,7 +14,7 @@ export const setNoteHeaderComponent = newNoteHeaderComponent => {
 export function registerHeaderProcessor() {
     const plugin = ReactComponentsPlugin.instance;
     plugin.registerMarkdownPostProcessor(async (_, ctx) => {
-        if (!ctx.containerEl?.hasClass('markdown-preview-section')) {
+        if (!ctx.sourcePath || (!ctx.containerEl?.hasClass('markdown-preview-section'))) {
             return;
         }
         const viewContainer = ctx.containerEl.parentElement;


### PR DESCRIPTION
Canvas chunks seem to have no source file. This breaks the header component renderer of the react components plugin.
This is a simple fix to check for that and ignore the headers for the canvas cards.

Tested by editing the main.js file in plugins because I couldn't get `npm i` to run properly for some reason.