### PR TITLE
JSX Support | Resolves #40

### DIFF
--- a/src/componentRegistry.tsx
+++ b/src/componentRegistry.tsx
@@ -42,15 +42,10 @@ export async function registerComponent(
 }
 
 export async function registerComponents(file: TFile, suppressComponentRefresh = false) {
-    if (file.extension != 'md') {
-        new Notice(`"${file.basename}.${file.extension}" is not a markdown file`);
-        return;
-    }
-
-    if (getPropertyValue('defines-react-components', file)) {
-        await registerCodeBlockComponents(file, suppressComponentRefresh);
-    } else if (file.path.startsWith(normalizePath(ReactComponentsPlugin.instance.settings.template_folder))) {
+    if (file.path.startsWith(normalizePath(ReactComponentsPlugin.instance.settings.template_folder))) {
         await registerFullFileComponent(file, suppressComponentRefresh);
+    } else if (file.extension == 'md' && getPropertyValue('defines-react-components', file)) {
+        await registerCodeBlockComponents(file, suppressComponentRefresh);
     }
 }
 
@@ -69,6 +64,11 @@ export async function registerCodeBlockComponents(file: TFile, suppressComponent
 }
 
 export async function registerFullFileComponent(file: TFile, suppressComponentRefresh = false) {
+    if (!['md', 'jsx', 'tsx'].contains(file.extension)) {
+        new Notice(`"${file.basename}.${file.extension}" is not a valid extension`);
+        return;
+    }
+
     if (!isVarName(file.basename)) {
         new Notice(`"${file.basename}" is not a valid function name`);
         return;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -56,7 +56,7 @@ export default class ReactComponentsPlugin extends Plugin {
     async loadComponents() {
         try {
             await awaitFilesLoaded();
-            for (const file of ReactComponentsPlugin.instance.app.vault.getMarkdownFiles()) {
+            for (const file of ReactComponentsPlugin.instance.app.vault.getFiles()) {
                 await registerComponents(file, true);
             }
             await refreshComponentScope();


### PR DESCRIPTION
Instead of only searching over markdown files, now Obsidian searches over all files, which will also include `.jsx` and `.tsx`.

Hopefully looking at all files instead of just markdown doesn't cause any noticeable performance hit. I didn't notice any.